### PR TITLE
Off-by-one error when navigating to previous page

### DIFF
--- a/src/js/pager.js
+++ b/src/js/pager.js
@@ -99,7 +99,7 @@ Pager.prototype.previous = function() {
 	var currentIndex = me.currentPage_;
 	var prevIndex = currentIndex - 1;
 
-	if (prevIndex <= 0) {
+	if (prevIndex < 0) {
 		prevIndex = me.allowsLoop_ ?
 			totalPages - 1 :
 			0;


### PR DESCRIPTION
The first page (index 0) was being skipped when allowLoops_ is set to true and navigating to the previous page. This had the result of jumping to the last page.
