### PR TITLE
Do not throw on empty targets

### DIFF
--- a/src/js/vanillabox.js
+++ b/src/js/vanillabox.js
@@ -17,7 +17,7 @@ const VanillaException = require('./exception.js');
 class Vanillabox {
 	constructor(config) {
 		if (!config.targets || config.targets.length === 0) {
-			throw new VanillaException(VanillaException.Types.NO_IMAGE);
+			return;
 		}
 
 		this.showed_ = false;


### PR DESCRIPTION
jQuery convention is to do nothing and not throw an error
when an operation is requested on an empty collection.
For an example, `$('.nothing').addClass('foo')` will do nothing and not throw.

It is reasonable to assume, that a jQuery plugin acts similarly.
Unfortunately, Vanillabox throws in such a situation:
`$('.nothing').vanillabox()`

With this change, Vanillabox does nothing, as expected.
